### PR TITLE
correctly set language in url

### DIFF
--- a/custom_components/azure_stt/stt.py
+++ b/custom_components/azure_stt/stt.py
@@ -248,7 +248,7 @@ class AzureSTTProvider(Provider):
             'Content-Type': 'audio/wav',
             'Ocp-Apim-Subscription-Key': self._api_key
         }
-        url = "https://" + self._region + ".stt.speech.microsoft.com/speech/recognition/conversation/cognitiveservices/v1?language=en-US&format=detailed"
+        url = f"https://{self._region}.stt.speech.microsoft.com/speech/recognition/conversation/cognitiveservices/v1?language={metadata.language}&format=detailed"
 
         def job():
             return requests.post(url, headers=headers, data=audio_data, stream=True)


### PR DESCRIPTION
Hi @Robert0309 , just noticed your azure fork of my integration, it's pretty neat! I gave it a quick try, seems to work fine.

Here's a small fix to properly set the language in the url, it was hard-coded to en-US.

