### PR TITLE
Use aiohttp, start the request before all data arrives

### DIFF
--- a/custom_components/azure_stt/stt.py
+++ b/custom_components/azure_stt/stt.py
@@ -248,7 +248,7 @@ class AzureSTTProvider(Provider):
             'Content-Type': 'audio/wav',
             'Ocp-Apim-Subscription-Key': self._api_key
         }
-        url = "https://" + self._region + ".stt.speech.microsoft.com/speech/recognition/conversation/cognitiveservices/v1?language=en-US&format=detailed"
+        url = f"https://{self._region}.stt.speech.microsoft.com/speech/recognition/conversation/cognitiveservices/v1?language={metadata.language}&format=detailed"
 
         def job():
             return requests.post(url, headers=headers, data=audio_data, stream=True)


### PR DESCRIPTION
Another improvement: replace requests by aiohttp. This has 2 advantages:

1. The request is started immediately, before we get all the data! aiohttp can fetch the data asynchronously from the `stream` iterator and forward them to the server as they arrive, so part of the work is done while the user is still talking and finishes faster.

    In my benchmarks:
    * without this change the request finishes ~ 1100 msecs after the end of the data stream
    * with the change, it finishes only ~ 300 msecs after the end of the data stream (a noticeable difference, feels more real-time).

4. Purely async code, no need for async_add_executor_job


PS. I wanted to do the same for google stt, but there it's more complicated due to the format of the request.